### PR TITLE
Updates for Numpy, StickyDesign compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+*.egg-info

--- a/piperine/Chen2013/energetics.py
+++ b/piperine/Chen2013/energetics.py
@@ -205,6 +205,17 @@ class energyfuncs:
         m[:,z:z+l+1] = (s1l == s2rl) * self.nndG[s1l]
         i = 0
         im = len(m)
+        
+        if fast:
+            try:
+                from stickydesign import _stickyext
+            except ImportError:
+                print("Error importing _stickyext. Falling back to slow mode.")
+                fast = False
+            except RuntimeError:
+                print("_stickyext was badly compiled. Falling back to slow mode.")
+                fast = False
+        
         # This needs to be changed to something faster
         if not fast:
             for xi in range(0,m.shape[0]):
@@ -222,7 +233,6 @@ class energyfuncs:
                 if not i%1000:
                     print("%d/%d" % (i,im))
         else:
-            from stickydesign import _stickyext
             x = m
             _stickyext.fastsub(x,r)
 

--- a/piperine/Srinivas2017/energetics.py
+++ b/piperine/Srinivas2017/energetics.py
@@ -189,6 +189,17 @@ class energyfuncs:
         m[:,z:z+l+1] = (s1l == s2rl) * self.nndG[s1l]
         i = 0
         im = len(m)
+        
+        if fast:
+            try:
+                from stickydesign import _stickyext
+            except ImportError:
+                print("Error importing _stickyext. Falling back to slow mode.")
+                fast = False
+            except RuntimeError:
+                print("_stickyext was badly compiled. Falling back to slow mode.")
+                fast = False
+        
         # This needs to be changed to something faster
         if not fast:
             for xi in range(0,m.shape[0]):
@@ -206,7 +217,6 @@ class energyfuncs:
                 if not i%1000:
                     print("%d/%d" % (i,im))
         else:
-            from stickydesign import _stickyext
             x = m
             _stickyext.fastsub(x,r)
 

--- a/piperine/designer.py
+++ b/piperine/designer.py
@@ -74,8 +74,7 @@ def call_design(basename,
                 old_output=False,
                 tempname=None,
                 extra_pars="",
-                findmfe=False,
-                spuriousbinary="spuriousSSM"):
+                findmfe=False):
     """ Generates an MFE file from a .pil file. This is a wrapper for a peppercompiler function.
 
     Args:
@@ -102,7 +101,7 @@ def call_design(basename,
         outfilename = '{}.mfe'.format(basename)
     design(basename, infilename, outfilename, cleanup, verbose, reuse,
            just_files, struct_orient, old_output, tempname, extra_pars,
-           findmfe, spuriousbinary)
+           findmfe)
     if not os.path.isfile(outfilename):
         raise RuntimeError('Expected MFE not created, expect SSM failure')
 
@@ -414,7 +413,7 @@ def write_sys_file(basename,
         basename = os.path.basename(basename)
 
     with open(sys_file, 'w') as f:
-        f.write("declare system " + basename + translation.param_string + " -> \n")
+        f.write("declare system " + str.replace(basename, ' ', '_') + translation.param_string + " -> \n")
         f.write("\n")
         # Comps is defined in Classes file
         for comp in translation.comps:

--- a/piperine/designer.py
+++ b/piperine/designer.py
@@ -194,19 +194,19 @@ def parse_parameter_line(line, translation=default_translation):
              "translation_scheme",
              "n"]
 
-    converters = [lambda x: np.float(x),
-                  lambda x: np.float(x),
-                  lambda x: np.float(x),
-                  lambda x: np.int(x),
+    converters = [lambda x: float(x),
+                  lambda x: float(x),
+                  lambda x: float(x),
+                  lambda x: int(x),
                   lambda x: x,
                   lambda x: x,
-                  lambda x: np.int(re.sub(r'\s*', '', x))]
+                  lambda x: int(re.sub(r'\s*', '', x))]
 
     # Design parameters are always integers
     if translation is not None:
         for param_term in default_translation.param_terms:
             terms.append(param_term)
-            converters.append(lambda x: np.int(x))
+            converters.append(lambda x: int(x))
 
     # Remove whitespace
     line = re.sub(r'^\s*|(?<=\s)\s+|\s*$', '', line)

--- a/piperine/tdm.py
+++ b/piperine/tdm.py
@@ -537,30 +537,30 @@ def Spurious_Weighted_Score(basename,
     lines = spc_text[spc_text.rfind('spurious1'):].split('\n')
     i, j = [ int(x) for x in re.findall(num, lines[0])[1:]]
     w = w_lin[i-1:j]
-    vec = np.array([ np.float(x) for x in re.findall(num, lines[2])])
+    vec = np.array([ float(x) for x in re.findall(num, lines[2])])
     score_vec = vec * w
     mis_intra_score = score_vec.sum()  #/ num_strands
 
-    vec = np.array([ np.float(x) for x in re.findall(num, lines[4])])
+    vec = np.array([ float(x) for x in re.findall(num, lines[4])])
     score_vec = vec * w
     mis_inter_score = score_vec.sum()  #/ num_strands
 
     lines = spc_text[spc_text.rfind('spurious('):].split('\n')
     i, j = [ int(x) for x in re.findall(num, lines[0])]
     w = w_lin[i-1:j]
-    vec = np.array([ np.float(x) for x in re.findall(num, lines[2])])
+    vec = np.array([ float(x) for x in re.findall(num, lines[2])])
     score_vec = vec * w
     spc_intra_score = score_vec.sum()  #/ num_strands
 
-    vec = np.array([ np.float(x) for x in re.findall(num, lines[4])])
+    vec = np.array([ float(x) for x in re.findall(num, lines[4])])
     score_vec = vec * w
     spc_inter_score = score_vec.sum()  #/ num_strands
 
     vec_str = spc_text[spc_text.rfind('** score_verboten'):]
-    verboten_score = np.float(re.findall(num, vec_str)[0])  #/ num_strands
+    verboten_score = float(re.findall(num, vec_str)[0])  #/ num_strands
 
     vec_str = spc_text[spc_text.rfind('-weighted score = '):].split('\n')[0]
-    wsi_score = np.float(re.findall(num, vec_str)[-1])  #/ num_strands
+    wsi_score = float(re.findall(num, vec_str)[-1])  #/ num_strands
 
     if clean:
         for f in [fixed_file, compiled_file, save_file, out_file,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='piperine',
     version='0.4a',
 
     packages=['piperine', 'piperine.tests', 'piperine.Srinivas2017', 'piperine.Chen2013'],
-    install_requires=["numpy","scipy", "stickydesign <0.9,>=0.8.4", "peppercompiler"],
+    install_requires=["numpy","scipy","stickydesign >=0.8.4,!=0.9.0.a1","peppercompiler >= 0.1.4"],
     include_package_data=True,
 
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='piperine',
     version='0.4a',
 
     packages=['piperine', 'piperine.tests', 'piperine.Srinivas2017', 'piperine.Chen2013'],
-    install_requires=["numpy","scipy", "stickydesign", "peppercompiler"],
+    install_requires=["numpy","scipy", "stickydesign <0.9,>=0.8.4", "peppercompiler"],
     include_package_data=True,
 
     package_data={


### PR DESCRIPTION
These changes allow Piperine to work with more recent versions of Python (eg, 3.12) and Numpy (eg, 1.26).  They also change the dependency requirements to use StickyDesign ≥ 0.8.4, which fixes a build problem for _stickyext with more recent Numpy versions, and automatically use the `fast=False` pure-Python method in both Piperine energetics modules if _stickyext was still not built successfully.

I'm currently waiting on confirmation that this works for other people.